### PR TITLE
[FEAT] : users entity feat

### DIFF
--- a/stepwise_back/src/main/java/com/example/stepwise_back/domain/post/entity/Post.java
+++ b/stepwise_back/src/main/java/com/example/stepwise_back/domain/post/entity/Post.java
@@ -1,11 +1,12 @@
 package com.example.stepwise_back.domain.post.entity;
 
 import com.example.stepwise_back.domain.base.BaseEntity;
+import com.example.stepwise_back.domain.users.entity.Users;
 import jakarta.persistence.*;
 import lombok.*;
 
 @Getter
-@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA용 기본 생성자
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
 @Entity
@@ -23,8 +24,14 @@ public class Post extends BaseEntity {
     @Column(name = "body")
     private String body;
 
+    @Setter
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id") // Users 테이블의 PK를 참조하는 외래키
+    private Users user;
+
     public void update(String body, String title){
         this.title = title;
         this.body = body;
     }
+
 }

--- a/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/entity/Users.java
+++ b/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/entity/Users.java
@@ -1,10 +1,12 @@
 package com.example.stepwise_back.domain.users.entity;
 
 import com.example.stepwise_back.domain.base.BaseEntity;
-import jakarta.persistence.Column;
-import jakarta.persistence.Entity;
-import jakarta.persistence.Table;
+import com.example.stepwise_back.domain.post.entity.Post;
+import jakarta.persistence.*;
 import lombok.*;
+
+import java.util.ArrayList;
+import java.util.List;
 
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA용 기본 생성자
@@ -23,12 +25,27 @@ public class Users extends BaseEntity {
     @Column(name = "nick_name", nullable = false)
     private String nickName;
 
+    @OneToMany(mappedBy = "user", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Post> posts = new ArrayList<>();
+
+
     public void updateNickName(String nickName){
         this.nickName = nickName;
     }
 
     public void updatePassword(String password){
         this.password = password;
+    }
+
+
+    public void addPost(Post post) {
+        posts.add(post);
+        post.setUser(this);
+    }
+
+    public void removePost(Post post) {
+        posts.remove(post);
+        post.setUser(null);
     }
 
 }

--- a/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/entity/Users.java
+++ b/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/entity/Users.java
@@ -1,0 +1,34 @@
+package com.example.stepwise_back.domain.users.entity;
+
+import com.example.stepwise_back.domain.base.BaseEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Table;
+import lombok.*;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED) // JPA용 기본 생성자
+@AllArgsConstructor
+@Builder
+@Entity
+@Table(name = "users")
+public class Users extends BaseEntity {
+
+    @Column(name = "user_name", nullable = false)
+    private String userName;
+
+    @Column(name = "password", nullable = false)
+    private String password;
+
+    @Column(name = "nick_name", nullable = false)
+    private String nickName;
+
+    public void updateNickName(String nickName){
+        this.nickName = nickName;
+    }
+
+    public void updatePassword(String password){
+        this.password = password;
+    }
+
+}


### PR DESCRIPTION
# User Entity Feat

## 요구 사항

<img width="833" height="336" alt="image" src="https://github.com/user-attachments/assets/b9bbead4-ced4-4cdd-8274-8cc5e59dc746" />


## 요구 사항 적용 방식
### 1.  RDB 종류 관계 없는 Class 파일.
**MySQL 등 일부 RDBMS에서는 user가 예약어로 지정**되어 있어, **테이블명을 user로 사용하는 것이 불가능**합니다.
따라서 사용자 정보를 저장하는 테이블명은 user 대신 다음과 같은 대체하려고 생각하였습니다.
1. users
2. "user"
3. member
4. members
5. app_user
6. account
7. customer
그중 가장 보편적으로 사용되는 **users**를 테이블명으로 채택하였습니다.

### 2.  User와 Post는 서로 연관 관계를 맺고 있어야함.

User와 Post는 1:N 관계를 가지도록 설계합니다.
이를 위해 JPA에서 @OneToMany와 @ManyToOne 어노테이션을 활용하였으며,
Users 엔티티에서 orphanRemoval = true 옵션을 지정하여,
사용자와 게시글 간 연결이 끊어질 경우 해당 게시글이 DB에서 자동 삭제되도록 구현하였습니다.


### 3. PassWord 속성 암호화 
비밀번호(password) 필드는 DB에 문자열(String) 형태로 저장하되,
비즈니스 로직 레이어에서 암호화 작업을 수행하여 안전하게 관리할 계획입니다.

