### PR TITLE
[FEAT] Id 중복 체크 API 구현

### DIFF
--- a/stepwise_back/build.gradle
+++ b/stepwise_back/build.gradle
@@ -35,4 +35,7 @@ dependencies {
 
 tasks.named('test') {
 	useJUnitPlatform()
+	//Java HotSpot(TM) 64-Bit Server VM warning: Sharing is only supported for boot loader classes because bootstrap classpath has been appended
+	//해당 오류 해결
+	jvmArgs '-Xshare:off'
 }

--- a/stepwise_back/src/main/java/com/example/stepwise_back/domain/base/AvailableResponse.java
+++ b/stepwise_back/src/main/java/com/example/stepwise_back/domain/base/AvailableResponse.java
@@ -1,0 +1,10 @@
+package com.example.stepwise_back.domain.base;
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class AvailableResponse {
+    private Boolean available;
+}

--- a/stepwise_back/src/main/java/com/example/stepwise_back/domain/base/ResponseDTO.java
+++ b/stepwise_back/src/main/java/com/example/stepwise_back/domain/base/ResponseDTO.java
@@ -17,4 +17,5 @@ public class ResponseDTO<T>{
 
         @JsonProperty("result")
         private T result;
+
 }

--- a/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/controller/UsersController.java
+++ b/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/controller/UsersController.java
@@ -19,7 +19,7 @@ public class UsersController {
     private final UserService userService;
 
     @GetMapping("/check-id")
-    public ResponseEntity<ResponseDTO<AvailableResponse>> isUserIdDuplicated(@RequestParam("userId") String userId){
+    public ResponseEntity<ResponseDTO<AvailableResponse>> isUserIdDuplicated(@RequestParam(name = "userId") String userId){
 
         return ResponseEntity.ok().body(ResponseDTO.<AvailableResponse>builder()
                 .isSuccess(true)

--- a/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/controller/UsersController.java
+++ b/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/controller/UsersController.java
@@ -1,0 +1,29 @@
+package com.example.stepwise_back.domain.users.controller;
+
+import com.example.stepwise_back.domain.base.AvailableResponse;
+import com.example.stepwise_back.domain.base.NullResponse;
+import com.example.stepwise_back.domain.base.ResponseDTO;
+import com.example.stepwise_back.domain.users.service.UserService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/users")
+@RequiredArgsConstructor
+public class UsersController {
+
+    private final UserService userService;
+
+    @GetMapping("/check-id")
+    public ResponseEntity<ResponseDTO<AvailableResponse>> isUserIdDuplicated(@RequestParam("userId") String userId){
+
+        return ResponseEntity.ok().body(ResponseDTO.<AvailableResponse>builder()
+                .isSuccess(true)
+                .stateCode(200)
+                .result(AvailableResponse.builder().available(userService.validateUserIdUniqueness(userId)).build()).build());
+    }
+}

--- a/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/repostiory/UserRepository.java
+++ b/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/repostiory/UserRepository.java
@@ -3,7 +3,7 @@ package com.example.stepwise_back.domain.users.repostiory;
 import com.example.stepwise_back.domain.users.entity.Users;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-public interface UsersRepository extends JpaRepository<Users, Long> {
+public interface UserRepository extends JpaRepository<Users, Long> {
     Boolean existsUsersByUserId(String userID);
 
 }

--- a/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/repostiory/UsersRepository.java
+++ b/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/repostiory/UsersRepository.java
@@ -1,0 +1,9 @@
+package com.example.stepwise_back.domain.users.repostiory;
+
+import com.example.stepwise_back.domain.users.entity.Users;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface UsersRepository extends JpaRepository<Users, Long> {
+    Boolean existsUsersByUserId(String userID);
+
+}

--- a/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/service/UserService.java
+++ b/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/service/UserService.java
@@ -16,7 +16,7 @@ public interface UserService {
 
     public UserLoginOutput login(UserLoginInput userLoginInput);
 
-    public void validateNicknameUniqueness(String nickname);
+    public boolean validateNicknameUniqueness(String nickname);
 
-    public void validateUserIdUniqueness(String userId);
+    public boolean validateUserIdUniqueness(String userId);
 }

--- a/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/service/UserServiceImpl.java
+++ b/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/service/UserServiceImpl.java
@@ -1,6 +1,6 @@
 package com.example.stepwise_back.domain.users.service;
 
-import com.example.stepwise_back.domain.users.repostiory.UsersRepository;
+import com.example.stepwise_back.domain.users.repostiory.UserRepository;
 import com.example.stepwise_back.domain.users.service.dto.input.UserDeleteInput;
 import com.example.stepwise_back.domain.users.service.dto.input.UserLoginInput;
 import com.example.stepwise_back.domain.users.service.dto.input.UserNicknameUpdateInput;
@@ -13,7 +13,7 @@ import org.springframework.stereotype.Service;
 @RequiredArgsConstructor
 public class UserServiceImpl implements UserService{
 
-    private final UsersRepository usersRepository;
+    private final UserRepository userRepository;
 
     @Override
     public UserRegisterOutput register(UserRegisterInput userRegisterInput) {
@@ -47,6 +47,6 @@ public class UserServiceImpl implements UserService{
 
     @Override
     public boolean validateUserIdUniqueness(String userId) {
-        return usersRepository.existsUsersByUserId(userId);
+        return userRepository.existsUsersByUserId(userId);
     }
 }

--- a/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/service/UserServiceImpl.java
+++ b/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/service/UserServiceImpl.java
@@ -1,12 +1,20 @@
 package com.example.stepwise_back.domain.users.service;
 
+import com.example.stepwise_back.domain.users.repostiory.UsersRepository;
 import com.example.stepwise_back.domain.users.service.dto.input.UserDeleteInput;
 import com.example.stepwise_back.domain.users.service.dto.input.UserLoginInput;
 import com.example.stepwise_back.domain.users.service.dto.input.UserNicknameUpdateInput;
 import com.example.stepwise_back.domain.users.service.dto.input.UserRegisterInput;
 import com.example.stepwise_back.domain.users.service.dto.output.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
 
+@Service
+@RequiredArgsConstructor
 public class UserServiceImpl implements UserService{
+
+    private final UsersRepository usersRepository;
+
     @Override
     public UserRegisterOutput register(UserRegisterInput userRegisterInput) {
         return null;
@@ -39,6 +47,6 @@ public class UserServiceImpl implements UserService{
 
     @Override
     public boolean validateUserIdUniqueness(String userId) {
-        return false;
+        return usersRepository.existsUsersByUserId(userId);
     }
 }

--- a/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/service/UserServiceImpl.java
+++ b/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/service/UserServiceImpl.java
@@ -1,0 +1,44 @@
+package com.example.stepwise_back.domain.users.service;
+
+import com.example.stepwise_back.domain.users.service.dto.input.UserDeleteInput;
+import com.example.stepwise_back.domain.users.service.dto.input.UserLoginInput;
+import com.example.stepwise_back.domain.users.service.dto.input.UserNicknameUpdateInput;
+import com.example.stepwise_back.domain.users.service.dto.input.UserRegisterInput;
+import com.example.stepwise_back.domain.users.service.dto.output.*;
+
+public class UserServiceImpl implements UserService{
+    @Override
+    public UserRegisterOutput register(UserRegisterInput userRegisterInput) {
+        return null;
+    }
+
+    @Override
+    public UserPasswordUpdateOutput updatePassword(UserNicknameUpdateInput userNicknameUpdateInput) {
+        return null;
+    }
+
+    @Override
+    public UserNicknameUpdateOutput updateNickname(UserNicknameUpdateInput userNicknameUpdateInput) {
+        return null;
+    }
+
+    @Override
+    public UserDeleteOutput deleteUser(UserDeleteInput userDeleteInput) {
+        return null;
+    }
+
+    @Override
+    public UserLoginOutput login(UserLoginInput userLoginInput) {
+        return null;
+    }
+
+    @Override
+    public boolean validateNicknameUniqueness(String nickname) {
+        return false;
+    }
+
+    @Override
+    public boolean validateUserIdUniqueness(String userId) {
+        return false;
+    }
+}

--- a/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/service/UserServiceImpl.java
+++ b/stepwise_back/src/main/java/com/example/stepwise_back/domain/users/service/UserServiceImpl.java
@@ -47,6 +47,6 @@ public class UserServiceImpl implements UserService{
 
     @Override
     public boolean validateUserIdUniqueness(String userId) {
-        return userRepository.existsUsersByUserId(userId);
+        return !userRepository.existsUsersByUserId(userId);
     }
 }

--- a/stepwise_back/src/test/java/com/example/stepwise_back/domain/users/controller/UserControllerTest.java
+++ b/stepwise_back/src/test/java/com/example/stepwise_back/domain/users/controller/UserControllerTest.java
@@ -1,0 +1,57 @@
+package com.example.stepwise_back.domain.users.controller;
+
+import com.example.stepwise_back.domain.users.service.UserService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.*;
+
+
+public class UserControllerTest {
+
+    private final UserService userService = Mockito.mock(UserService.class);
+    private final UsersController usersController = new UsersController(userService);
+    private final MockMvc mockMvc = MockMvcBuilders.standaloneSetup(usersController).build();
+
+    @Test
+    @DisplayName("1. 이미 있는 아이디일 때 false 반환 테스트")
+    public void givenExistingUserId_whenCheckId_thenReturnFalse() throws Exception {
+        when(userService.validateUserIdUniqueness("existingUser")).thenReturn(false);
+
+        mockMvc.perform(get("/users/check-id")
+                        .param("userId", "existingUser")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.stateCode").value(200))
+                .andExpect(jsonPath("$.result.available").value(false));
+    }
+
+    @Test
+    @DisplayName("2. 없는 아이디일 때 true 반환 테스트")
+    public void givenNewUserId_whenCheckId_thenReturnTrue() throws Exception {
+        when(userService.validateUserIdUniqueness("newUser")).thenReturn(true);
+
+        mockMvc.perform(get("/users/check-id")
+                        .param("userId", "newUser")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.success").value(true))
+                .andExpect(jsonPath("$.stateCode").value(200))
+                .andExpect(jsonPath("$.result.available").value(true));
+    }
+
+    @Test
+    @DisplayName("3. 매개변수 없이 호출 시 예외 발생 테스트")
+    public void givenNoUserIdParam_whenCheckId_thenBadRequest() throws Exception {
+        mockMvc.perform(get("/users/check-id")
+                        .accept(MediaType.APPLICATION_JSON))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
## 동일한 ID 가 있는 지 확인하는 방법
JpaRepository가 제공하는 existsByXXX 메서드를 활용하여, 데이터베이스에 해당 ID가 존재하는지 확인합니다.
이 메서드는 DB 내에 값이 존재하면 true, 없으면 false를 반환합니다.

비즈니스 로직에서는,
- **true인 경우에는** 이미 존재한다는 뜻이므로 해당 ID는 사용할 수 없어 결과는 **false로 반환**하고,
- **false인 경우**에는 해당 ID가 존재하지 않아 사용 가능하므로 결과를 **true로 반환**하도록 설계했습니다.
- 
## 동일한 Id 가 있을 때 Body로 구분
ID 사용 가능 여부를 true 혹은 false로 전달하기 위해 **AvailableResponse 클래스**를 만들었습니다.
이를 통해 HTTP 200 상태 코드 내에서, 응답 바디의 available 필드를 보고 사용 가능 여부를 쉽게 판단할 수 있도록 하였습니다.

**AvailableResponse 클래스**는 닉네임, ID뿐만 아니라 앞으로 확장 가능성이 있는 여러 사용 가능 여부 정보를 담기 위해, 공통적으로 활용할 수 있는 형태로 설계되어 base 패키지에 위치시켰습니다.

